### PR TITLE
Add ability to send extra debugging information with Node.js SDK

### DIFF
--- a/codelighthouse.js
+++ b/codelighthouse.js
@@ -69,11 +69,11 @@ class CodeLighthouse {
 	}
 
 	// SEND THE ERROR TO OUR BACKEND
-	error(error, email=this.default_email, extra_data = {}) {
+	error(error, email=this.default_email, data=null) {
 
 		// CONSTRUCT AN ERROR
 		const clh_error = new CodeLighthouseError(error, email, this.resource_group, this.resource_name,
-			this.github_repo);
+			this.github_repo, data);
 
 		// SEND THE ERROR
 		this.web_client.send_error(clh_error.json());

--- a/docs/node/CodeLighthouses-Node.js-SDK.md
+++ b/docs/node/CodeLighthouses-Node.js-SDK.md
@@ -89,7 +89,7 @@ const codelighthouse = new CodeLighthouse(
 Once you have configured the SDK, you have a few options on how to use it. 
 
 ### The Global Handler
-By default, the CodeLighthouse SDK will send error notifications for all uncaught exceptions and uncaught promise rejections to the user specified by `default_email` in the configuration. To turn this off, set the parameter `enable_global_handler` to `true`.
+By default, the CodeLighthouse SDK will send error notifications for all uncaught exceptions and uncaught promise rejections to the user specified by `default_email` in the configuration. To turn this off, set the parameter `enable_global_handler` to `false`.
 
 **Note that frameworks such as Express.js may handle errors that occur in routes, such that application errors will not be caught by the global handler.** Please see the section on our Express.js integration for information on how to catch errors within routes. Looking for a different framework? [Contact us](https://codelighthouse.io/contact).
 

--- a/docs/node/CodeLighthouses-Node.js-SDK.md
+++ b/docs/node/CodeLighthouses-Node.js-SDK.md
@@ -79,7 +79,7 @@ const CodeLighthouse = require('codelighthouse');
 const codelighthouse = new CodeLighthouse(
     organization_name="CodeLighthouse, LLC",
     api_key="your API Key",
-    default_email="code owner's email address"
+    default_email="code owner's email address",
     resource_group="serverless-applications",
     resource_name="notifications-app"
 )
@@ -116,6 +116,24 @@ catch (err) {
   codelighthouse.error(err, "an_email@your_company.com");
 }
 ```
+
+When you're sending errors manually using this method, you can also optionally attach additional data that will show
+up in the admin panel in the error view. The most common use case for this is including additional information that will
+help your developers to identify and debug the error. For example, you could attach information about the currently
+logged-in user that experienced the error, connection information, or other application state information.
+
+```javascript
+try {
+  // YOUR CODE HERE
+}
+catch (err) {
+  codelighthouse.error(err, "an_email@your_company.com", data=some_data);
+}
+```
+
+Make sure that the data you're passing via the `data` argument can be serialized into JSON. Object literals and native 
+types will work easily, but if you choose to pass a more complicated object, ensure that it is serializable to JSON and 
+that it does not contain any circular references. 
 
 ### Express.js Integration
 While Express.js has the potential to distrupt some SDK functionalities as described above, it also presented an opportunity for integration. The SDK currently has two methods that allow for integration into Express:
@@ -160,7 +178,7 @@ const CodeLighthouse = require('codelighthouse');
 const codelighthouse = new CodeLighthouse(
     organization_name="CodeLighthouse, LLC",
     api_key="your API Key",
-    default_email="doesnotexist@codelighthouse.io" 
+    default_email="doesnotexist@codelighthouse.io",
     resource_group="serverless-applications",
     resource_name="notifications-app"
 )
@@ -209,7 +227,7 @@ const CodeLighthouse = require('codelighthouse');
 const codelighthouse = new CodeLighthouse(
     organization_name="CodeLighthouse, LLC",
     api_key="your API Key",
-    default_email="doesnotexist@codelighthouse.io" 
+    default_email="doesnotexist@codelighthouse.io",
     resource_group="serverless-applications",
     resource_name="notifications-app"
 )

--- a/lib/codelighthouse_error.js
+++ b/lib/codelighthouse_error.js
@@ -28,7 +28,7 @@ class CodeLighthouseError {
 				'function': trace.methodName
 			})
 		}
-		this.data['stack_trace'] = formatted_trace;
+		this.data['stack_trace'] = error.stack;
 
 		// ADD METHOD NAME AND ARGUMENTS OF TOP-LEVEL ERROR
 		this.data['arguments'] = parsed_stack_trace[0].arguments;    // ARGUMENTS IS A RESERVED WORD SO DO IT THIS WAY

--- a/lib/codelighthouse_error.js
+++ b/lib/codelighthouse_error.js
@@ -4,7 +4,7 @@ class CodeLighthouseError {
 
 	// CONSTRUCT THE OBJECT
 	constructor (error, email,  resource_group=null, resource_name=null,
-				 github_repo=null) {
+				 github_repo=null, user_data=null) {
 
 		// HAVE TO USE AN OBJECT LITERAL TO STORE DATA - WOULD STORE ALL AT CLASS LEVEL, BUT SOME ARE
 		// RESERVED WORDS (LIKE ARGUMENTS AND FUNCTION) SO CAN'T DIRECTORY STORE ON this
@@ -15,6 +15,7 @@ class CodeLighthouseError {
 			'github_repo': github_repo,
 			'resource_group': resource_group,
 			'resource_name': resource_name
+			'user_data': user_data
 		}
 
 		// ADD THE STACK TRACE

--- a/lib/codelighthouse_error.js
+++ b/lib/codelighthouse_error.js
@@ -14,21 +14,12 @@ class CodeLighthouseError {
 			'email': email,
 			'github_repo': github_repo,
 			'resource_group': resource_group,
-			'resource_name': resource_name
+			'resource_name': resource_name,
 			'user_data': user_data
 		}
 
 		// ADD THE STACK TRACE
-		const formatted_trace = [];
 		const parsed_stack_trace = stackTraceParser.parse(error.stack);
-		for (let trace of parsed_stack_trace) {
-			formatted_trace.push({
-				'file': trace.file,
-				'line': '',        // NOT AVAILABLE IN JAVASCRIPT
-				'lineno': trace.lineNumber,
-				'function': trace.methodName
-			})
-		}
 		this.data['stack_trace'] = error.stack;
 
 		// ADD METHOD NAME AND ARGUMENTS OF TOP-LEVEL ERROR

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codelighthouse",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "CodeLighthouse's Node.js SDK. For more information on CodeLighthouse, check out codelighthouse.io!",
   "main": "codelighthouse.js",
   "scripts": {},


### PR DESCRIPTION
fixes CLH-105, fixes CLH-123

Update documentation, send normal stack trace instead of JSON, add abillity to send extra debugging information